### PR TITLE
Make mypy happy (explicit reexport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/decimify/__init__.py
+++ b/decimify/__init__.py
@@ -1,1 +1,1 @@
-from decimify.parser import decimify  # noqa: F401
+from decimify.parser import decimify as decimify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ lint.ignore = ["D1"] # pydocstyle missing docs
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**" = ["S101", "ARG002"]
+"__init__.py" = ["PLC0414"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
## What is the current behavior?

Mypy in strict mode is not happy about the library: 
```
error: Module "decimify" does not explicitly export attribute "decimify"  [attr-defined]
    from decimify import decimify
```

The error is caused by rule [--no-implicit-reexport](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport). There are two ways how to fix it: either define `__all__` in `__init__.py` or use import aliases so that other modules can import it. In this PR I added an alias for an import in `__init__.py`.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added an import alias
- Ignored ruff rule PLC0414 (see: https://github.com/astral-sh/ruff/issues/6294)
- Ignored `.idea` folder for contributors using Pycharm (such as me)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No